### PR TITLE
set tarfile manually (proxmox 7 doesnt set it anymore, probably a bug)

### DIFF
--- a/vzdump2influx.sh
+++ b/vzdump2influx.sh
@@ -29,12 +29,7 @@ if [ "$1" == "log-end" ]; then
             SPEED=`cat ${LOGFILE} | grep -o -P "(?<=.iB, ).*(?=.iB\/s)"`
         fi
         DURATION=$((`cat ${LOGFILE} |grep -o -P "(?<=\()[0-9][0-9]:[0-9][0-9]:[0-9][0-9](?=\))"|awk -F':' '{print($1*3600)+($2*60)+$3}'`))
-<<<<<<< HEAD
         TARFILE=`cat ${LOGFILE} | grep -o -P "creating vzdump archive '\K[^']+"`
         /usr/bin/curl --request POST "$PROTOCOL://$HOSTNAME:$PORT/api/v2/write?org=$ORGANIZATION&bucket=$BUCKETNAME&precision=ns" --data-binary  "proxmox,host=$HOSTNAME,location=$LOCATIONCODE success=1,duration=$DURATION,speed=$SPEED,size=`stat -c%s $TARFILE`" --header "Authorization: Token $TOKEN" --header "Content-Type: text/plain; charset=utf-8" --header "Accept: application/json"
-=======
-        /usr/bin/curl -s -i -XPOST -u $DBUSER:$DBPASS "$DBPROTO://$DBHOST:$DBPORT/write?db=$DBNAME" --data-binary  "proxmox,host=$HOSTNAME,location=$LOCATIONCODE success=1,duration=$DURATION,speed=$SPEED,size=`stat -c%s $TARGET`" > /tmp/tst
-        echo $TARGET >> /tmp/tst
->>>>>>> 3f3d2ca38318b9a001f3b0821db1f6aafbfd7db6
     fi
 fi

--- a/vzdump2influx.sh
+++ b/vzdump2influx.sh
@@ -4,7 +4,7 @@ TOKEN=<TOKEN>
 ORGANIZATION=<ORGANIZATION>
 LOCATIONCODE=<LOCATIONCODE>
 PROTOCOL=<PROTOCOL> #HTTP or HTTPS
-HOSTNAME=<HOSTNAME>
+DBHOSTNAME=<DBHOSTNAME>
 PORT=<PORT>
 BUCKETNAME=<BUCKETNAME>
 DEBUG=false #Debug mode, copy all logs to /tmp/timestamp
@@ -21,7 +21,7 @@ if [ "$1" == "log-end" ]; then
     fi
     if [ `cat ${LOGFILE} | grep ERROR | wc -l` -gt 0 ]; then
         DURATION=$((`date +%s`-`sed '1q;d' /tmp/backup-info`))
-        /usr/bin/curl --request POST "$PROTOCOL://$HOSTNAME:$PORT/api/v2/write?org=$ORGANIZATION&bucket=$BUCKETNAME&precision=ns" --data-binary  "proxmox,host=$HOSTNAME,location=$LOCATIONCODE success=0,duration=$DURATION,speed=0,size=0" --header "Authorization: Token $TOKEN" --header "Content-Type: text/plain; charset=utf-8" --header "Accept: application/json"
+        /usr/bin/curl --request POST "$PROTOCOL://$DBHOSTNAME:$PORT/api/v2/write?org=$ORGANIZATION&bucket=$BUCKETNAME&precision=ns" --data-binary  "proxmox,host=$HOSTNAME,location=$LOCATIONCODE success=0,duration=$DURATION,speed=0,size=0" --header "Authorization: Token $TOKEN" --header "Content-Type: text/plain; charset=utf-8" --header "Accept: application/json"
         rm /tmp/backup-info
     else
         SPEED=`cat ${LOGFILE} | grep -o -P "(?<=seconds \().*(?= MB\/s| MiB\/s)"`
@@ -30,6 +30,6 @@ if [ "$1" == "log-end" ]; then
         fi
         DURATION=$((`cat ${LOGFILE} |grep -o -P "(?<=\()[0-9][0-9]:[0-9][0-9]:[0-9][0-9](?=\))"|awk -F':' '{print($1*3600)+($2*60)+$3}'`))
         TARFILE=`cat ${LOGFILE} | grep -o -P "creating vzdump archive '\K[^']+"`
-        /usr/bin/curl --request POST "$PROTOCOL://$HOSTNAME:$PORT/api/v2/write?org=$ORGANIZATION&bucket=$BUCKETNAME&precision=ns" --data-binary  "proxmox,host=$HOSTNAME,location=$LOCATIONCODE success=1,duration=$DURATION,speed=$SPEED,size=`stat -c%s $TARFILE`" --header "Authorization: Token $TOKEN" --header "Content-Type: text/plain; charset=utf-8" --header "Accept: application/json"
+        /usr/bin/curl --request POST "$PROTOCOL://$DBHOSTNAME:$PORT/api/v2/write?org=$ORGANIZATION&bucket=$BUCKETNAME&precision=ns" --data-binary  "proxmox,host=$HOSTNAME,location=$LOCATIONCODE success=1,duration=$DURATION,speed=$SPEED,size=`stat -c%s $TARFILE`" --header "Authorization: Token $TOKEN" --header "Content-Type: text/plain; charset=utf-8" --header "Accept: application/json"
     fi
 fi

--- a/vzdump2influx.sh
+++ b/vzdump2influx.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 #Just a simple script to wtite some stats to InfluxDB about your backup. Based on vzdump hook method.
-DBUSER=<DBUSER>
-DBPASS=<DBPASS>
-DBPROTO=<DBPROTO> #HTTP or HTTPS
-DBHOST=<DBHOST>
-DBPORT=<DBPORT>
-DBNAME=<DBNAME>
-LOCATIONCODE=<LOCATION_CODE>
+TOKEN=<TOKEN>
+ORGANIZATION=<ORGANIZATION>
+LOCATIONCODE=<LOCATIONCODE>
+PROTOCOL=<PROTOCOL> #HTTP or HTTPS
+HOSTNAME=<HOSTNAME>
+PORT=<PORT>
+BUCKETNAME=<BUCKETNAME>
 DEBUG=false #Debug mode, copy all logs to /tmp/timestamp
 SPEED=""
 
@@ -21,7 +21,7 @@ if [ "$1" == "log-end" ]; then
     fi
     if [ `cat ${LOGFILE} | grep ERROR | wc -l` -gt 0 ]; then
         DURATION=$((`date +%s`-`sed '1q;d' /tmp/backup-info`))
-        /usr/bin/curl -s -i -XPOST -u $DBUSER:$DBPASS "$DBPROTO://$DBHOST:$DBPORT/write?db=$DBNAME" --data-binary  "proxmox,host=$HOSTNAME,location=$LOCATIONCODE success=0,duration=$DURATION,speed=0,size=0" > /tmp/tst
+        /usr/bin/curl --request POST "$PROTOCOL://$HOSTNAME:$PORT/api/v2/write?org=$ORGANIZATION&bucket=$BUCKETNAME&precision=ns" --data-binary  "proxmox,host=$HOSTNAME,location=$LOCATIONCODE success=0,duration=$DURATION,speed=0,size=0" --header "Authorization: Token $TOKEN" --header "Content-Type: text/plain; charset=utf-8" --header "Accept: application/json"
         rm /tmp/backup-info
     else
         SPEED=`cat ${LOGFILE} | grep -o -P "(?<=seconds \().*(?= MB\/s| MiB\/s)"`
@@ -29,7 +29,12 @@ if [ "$1" == "log-end" ]; then
             SPEED=`cat ${LOGFILE} | grep -o -P "(?<=.iB, ).*(?=.iB\/s)"`
         fi
         DURATION=$((`cat ${LOGFILE} |grep -o -P "(?<=\()[0-9][0-9]:[0-9][0-9]:[0-9][0-9](?=\))"|awk -F':' '{print($1*3600)+($2*60)+$3}'`))
+<<<<<<< HEAD
+        TARFILE=`cat ${LOGFILE} | grep -o -P "creating vzdump archive '\K[^']+"`
+        /usr/bin/curl --request POST "$PROTOCOL://$HOSTNAME:$PORT/api/v2/write?org=$ORGANIZATION&bucket=$BUCKETNAME&precision=ns" --data-binary  "proxmox,host=$HOSTNAME,location=$LOCATIONCODE success=1,duration=$DURATION,speed=$SPEED,size=`stat -c%s $TARFILE`" --header "Authorization: Token $TOKEN" --header "Content-Type: text/plain; charset=utf-8" --header "Accept: application/json"
+=======
         /usr/bin/curl -s -i -XPOST -u $DBUSER:$DBPASS "$DBPROTO://$DBHOST:$DBPORT/write?db=$DBNAME" --data-binary  "proxmox,host=$HOSTNAME,location=$LOCATIONCODE success=1,duration=$DURATION,speed=$SPEED,size=`stat -c%s $TARGET`" > /tmp/tst
         echo $TARGET >> /tmp/tst
+>>>>>>> 3f3d2ca38318b9a001f3b0821db1f6aafbfd7db6
     fi
 fi

--- a/vzdump2influx.sh
+++ b/vzdump2influx.sh
@@ -29,6 +29,7 @@ if [ "$1" == "log-end" ]; then
             SPEED=`cat ${LOGFILE} | grep -o -P "(?<=.iB, ).*(?=.iB\/s)"`
         fi
         DURATION=$((`cat ${LOGFILE} |grep -o -P "(?<=\()[0-9][0-9]:[0-9][0-9]:[0-9][0-9](?=\))"|awk -F':' '{print($1*3600)+($2*60)+$3}'`))
+        TARFILE=`cat ${LOGFILE} | grep -o -P "creating vzdump archive '\K[^']+"`
         /usr/bin/curl -s -i -XPOST -u $DBUSER:$DBPASS "$DBPROTO://$DBHOST:$DBPORT/write?db=$DBNAME" --data-binary  "proxmox,host=$HOSTNAME,location=$LOCATIONCODE success=1,duration=$DURATION,speed=$SPEED,size=`stat -c%s $TARFILE`" > /tmp/tst
         echo $TARFILE >> /tmp/tst
     fi

--- a/vzdump2influx.sh
+++ b/vzdump2influx.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 #Just a simple script to wtite some stats to InfluxDB about your backup. Based on vzdump hook method.
-DBUSER=<DBUSER>
-DBPASS=<DBPASS>
-DBPROTO=<DBPROTO> #HTTP or HTTPS
-DBHOST=<DBHOST>
-DBPORT=<DBPORT>
-DBNAME=<DBNAME>
-LOCATIONCODE=<LOCATION_CODE>
+TOKEN=<TOKEN>
+ORGANIZATION=<ORGANIZATION>
+LOCATIONCODE=<LOCATIONCODE>
+PROTOCOL=<PROTOCOL> #HTTP or HTTPS
+HOSTNAME=<HOSTNAME>
+PORT=<PORT>
+BUCKETNAME=<BUCKETNAME>
 DEBUG=false #Debug mode, copy all logs to /tmp/timestamp
 SPEED=""
 
@@ -21,7 +21,7 @@ if [ "$1" == "log-end" ]; then
     fi
     if [ `cat ${LOGFILE} | grep ERROR | wc -l` -gt 0 ]; then
         DURATION=$((`date +%s`-`sed '1q;d' /tmp/backup-info`))
-        /usr/bin/curl -s -i -XPOST -u $DBUSER:$DBPASS "$DBPROTO://$DBHOST:$DBPORT/write?db=$DBNAME" --data-binary  "proxmox,host=$HOSTNAME,location=$LOCATIONCODE success=0,duration=$DURATION,speed=0,size=0" > /tmp/tst
+        /usr/bin/curl --request POST "$PROTOCOL://$HOSTNAME:$PORT/api/v2/write?org=$ORGANIZATION&bucket=$BUCKETNAME&precision=ns" --data-binary  "proxmox,host=$HOSTNAME,location=$LOCATIONCODE success=0,duration=$DURATION,speed=0,size=0" --header "Authorization: Token $TOKEN" --header "Content-Type: text/plain; charset=utf-8" --header "Accept: application/json"
         rm /tmp/backup-info
     else
         SPEED=`cat ${LOGFILE} | grep -o -P "(?<=seconds \().*(?= MB\/s| MiB\/s)"`
@@ -30,7 +30,6 @@ if [ "$1" == "log-end" ]; then
         fi
         DURATION=$((`cat ${LOGFILE} |grep -o -P "(?<=\()[0-9][0-9]:[0-9][0-9]:[0-9][0-9](?=\))"|awk -F':' '{print($1*3600)+($2*60)+$3}'`))
         TARFILE=`cat ${LOGFILE} | grep -o -P "creating vzdump archive '\K[^']+"`
-        /usr/bin/curl -s -i -XPOST -u $DBUSER:$DBPASS "$DBPROTO://$DBHOST:$DBPORT/write?db=$DBNAME" --data-binary  "proxmox,host=$HOSTNAME,location=$LOCATIONCODE success=1,duration=$DURATION,speed=$SPEED,size=`stat -c%s $TARFILE`" > /tmp/tst
-        echo $TARFILE >> /tmp/tst
+        /usr/bin/curl --request POST "$PROTOCOL://$HOSTNAME:$PORT/api/v2/write?org=$ORGANIZATION&bucket=$BUCKETNAME&precision=ns" --data-binary  "proxmox,host=$HOSTNAME,location=$LOCATIONCODE success=1,duration=$DURATION,speed=$SPEED,size=`stat -c%s $TARFILE`" --header "Authorization: Token $TOKEN" --header "Content-Type: text/plain; charset=utf-8" --header "Accept: application/json"
     fi
 fi

--- a/vzdump2influx.sh
+++ b/vzdump2influx.sh
@@ -29,8 +29,7 @@ if [ "$1" == "log-end" ]; then
             SPEED=`cat ${LOGFILE} | grep -o -P "(?<=.iB, ).*(?=.iB\/s)"`
         fi
         DURATION=$((`cat ${LOGFILE} |grep -o -P "(?<=\()[0-9][0-9]:[0-9][0-9]:[0-9][0-9](?=\))"|awk -F':' '{print($1*3600)+($2*60)+$3}'`))
-        TARFILE=`cat ${LOGFILE} | grep -o -P "creating vzdump archive '\K[^']+"`
-        /usr/bin/curl -s -i -XPOST -u $DBUSER:$DBPASS "$DBPROTO://$DBHOST:$DBPORT/write?db=$DBNAME" --data-binary  "proxmox,host=$HOSTNAME,location=$LOCATIONCODE success=1,duration=$DURATION,speed=$SPEED,size=`stat -c%s $TARFILE`" > /tmp/tst
-        echo $TARFILE >> /tmp/tst
+        /usr/bin/curl -s -i -XPOST -u $DBUSER:$DBPASS "$DBPROTO://$DBHOST:$DBPORT/write?db=$DBNAME" --data-binary  "proxmox,host=$HOSTNAME,location=$LOCATIONCODE success=1,duration=$DURATION,speed=$SPEED,size=`stat -c%s $TARGET`" > /tmp/tst
+        echo $TARGET >> /tmp/tst
     fi
 fi


### PR DESCRIPTION
I noticed the backups arent pushed to influx anymore after proxmox 7 update.
The size is not set and this is due to the $TARFILE variable not being set in backup-start, backup-end and log-end stages.
Also logging a bug to proxmox for this.

Error in log;
`{"error":"unable to parse 'proxmox,host=code,location=homeservers success=1,duration=95,speed=65,size=': missing field value"}
`
I set the tarfile manually by parsing it from the logs and it works.